### PR TITLE
Feature/chd hdd

### DIFF
--- a/3rdparty/libchdr/src/libchdr_chd.c
+++ b/3rdparty/libchdr/src/libchdr_chd.c
@@ -90,8 +90,8 @@
 
 #define CHD_MAX_HUNK_SIZE				(128 * 1024 * 1024) /* hunk size probably shouldn't be more than 128MB */
 
-/* we're currently only using this for CD/DVDs, if we end up with more than 10GB data, it's probably invalid */
-#define CHD_MAX_FILE_SIZE				(10ULL * 1024 * 1024 * 1024)
+/* PCSX2 uses CHDs for both CD/DVD and HDD images. HDD images may be up to 2TB. */
+#define CHD_MAX_FILE_SIZE				(2ULL * 1024 * 1024 * 1024 * 1024)
 
 #define COOKIE_VALUE				0xbaadf00d
 #define MAX_ZLIB_ALLOCS				64

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ It targets platforms and software outside the usual retail console path, includi
 - Full security process support end to end.
 - Bring your own keys.
 - Support for all Konami Python 2 titles.
+- Support for CHD-compressed internal HDD images with writable overlays.
 - Switch keying mode between Developer, Retail, Arcade, and Prototype on both mechacon and memory cards.
 - Support raw PS2 memory card dumps with proper keying.
 - Support for utility discs such as HDD installers and DVD installers.
@@ -49,10 +50,11 @@ PCSX2 memory cards expect the ECC data to be present. Some memorycard dumping ut
 ### Konami Python 2
 Python 2 games require pairing of the game hdd image, the associated nvram, the white and black dongle data, as well as other hardware specifics like your e-amuse card id. This can all be configured through a `.py2` file that the game library scanner can read and interpret. Details on this file format are listed in this [wiki article](https://github.com/987123879113/pcsx2/wiki/PY2-Game-Entry-File-Example).
 
+Python 2 HDD images can be provided as either raw `.raw` files or CHD-compressed `.chd` files. CHD images are opened read-only as the base image to reduce collection size, while any writes made by the emulated HDD are stored in a separate writable overlay under `hdd-overlays/` in the emulator settings directory. This keeps the compressed source CHD unchanged and allows per-install or per-user runtime data to persist. To reset a CHD-backed HDD to its base image, close the emulator and delete the matching `.overlay` and `.map` files.
+
 The Python 2 IO board (P2IO) is available as a USB device in the controller configuration screen. It must be plugged into port 1 for the inputs and dongles to be authenticated correctly.
 ![p2io-config.png](docs/p2io-config.png)
 
 ### Retail/Utility Disks
 If your bios is a proper dump, and your mechacon and memory cards are setup in Retail mode, then any HDD based functionality will work like a real console. This lets you do things like run the HDD Utility disks, boot FMCB, install game HDD functionality or boot DVD update payloads.
 ![hdd-utility.png](docs/hdd-utility.png)
-

--- a/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
@@ -12,6 +12,7 @@
 #include "pcsx2/Host.h"
 #include "pcsx2/INISettingsInterface.h"
 
+#include "DEV9/ATA/HddChdImage.h"
 #include "DEV9SettingsWidget.h"
 #include "QtHost.h"
 #include "QtUtils.h"
@@ -608,7 +609,7 @@ void DEV9SettingsWidget::onHddBrowseFileClicked()
 	QString path =
 		QDir::toNativeSeparators(QFileDialog::getSaveFileName(QtUtils::GetRootWidget(this), tr("HDD Image File"),
 			!m_ui.hddFile->text().isEmpty() ? m_ui.hddFile->text() : (!m_ui.hddFile->placeholderText().isEmpty() ? m_ui.hddFile->placeholderText() : "DEV9hdd.raw"),
-			tr("HDD (*.raw)"), nullptr, QFileDialog::DontConfirmOverwrite));
+			tr("HDD (*.raw *.chd)"), nullptr, QFileDialog::DontConfirmOverwrite));
 
 	if (path.isEmpty())
 		return;
@@ -741,9 +742,10 @@ void DEV9SettingsWidget::UpdateHddSizeUIValues()
 	if (!FileSystem::FileExists(hddPath.c_str()))
 		return;
 
-	const s64 size = FileSystem::GetPathFileSize(hddPath.c_str());
-	if (size < 0)
+	const std::optional<u64> logical_size = ChdHddImage::GetHddImageLogicalSize(hddPath);
+	if (!logical_size.has_value())
 		return;
+	const s64 size = static_cast<s64>(logical_size.value());
 
 	if (size > static_cast<s64>(120) * 1024 * 1024 * 1024)
 		m_ui.hddLBA48->setChecked(true);

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -289,6 +289,7 @@ set(pcsx2DEV9Sources
 	DEV9/ATA/ATA_Info.cpp
 	DEV9/ATA/ATA_State.cpp
 	DEV9/ATA/ATA_Transfer.cpp
+	DEV9/ATA/HddChdImage.cpp
 	DEV9/ATA/HddCreate.cpp
 	DEV9/InternalServers/DHCP_Logger.cpp
 	DEV9/InternalServers/DHCP_Server.cpp
@@ -328,6 +329,7 @@ set(pcsx2DEV9Sources
 set(pcsx2DEV9Headers
 	DEV9/AdapterUtils.h
 	DEV9/ATA/ATA.h
+	DEV9/ATA/HddChdImage.h
 	DEV9/ATA/HddCreate.h
 	DEV9/DEV9.h
 	DEV9/InternalServers/DHCP_Logger.h

--- a/pcsx2/DEV9/ATA/ATA.h
+++ b/pcsx2/DEV9/ATA/ATA.h
@@ -8,11 +8,14 @@
 #include <atomic>
 #include <mutex>
 #include <condition_variable>
+#include <memory>
 
 #include "common/RedtapeWindows.h"
 #include "common/Path.h"
 
 #include "DEV9/SimpleQueue.h"
+
+class ChdHddImage;
 
 class ATA
 {
@@ -25,6 +28,7 @@ private:
 	bool lba48Supported = false;
 
 	std::FILE* hddImage = nullptr;
+	std::unique_ptr<ChdHddImage> hddChdImage;
 	u64 hddImageSize;
 
 	bool hddSparse = false;

--- a/pcsx2/DEV9/ATA/ATA_State.cpp
+++ b/pcsx2/DEV9/ATA/ATA_State.cpp
@@ -5,6 +5,7 @@
 #include "common/FileSystem.h"
 
 #include "ATA.h"
+#include "HddChdImage.h"
 #include "DEV9/DEV9.h"
 
 #if _WIN32
@@ -30,8 +31,7 @@ ATA::ATA()
 
 ATA::~ATA()
 {
-	if (hddImage)
-		std::fclose(hddImage);
+	Close();
 }
 
 int ATA::Open(const std::string& hddPath)
@@ -46,12 +46,29 @@ int ATA::Open(const std::string& hddPath)
 	if (!FileSystem::FileExists(hddPath.c_str()))
 		return -1;
 
-	hddImage = FileSystem::OpenCFile(hddPath.c_str(), "r+b");
-	const s64 size = hddImage ? FileSystem::FSize64(hddImage) : -1;
-	if (!hddImage || size < 0)
+	const bool use_chd = ChdHddImage::IsChdFileName(hddPath);
+	if (use_chd)
 	{
-		Console.Error("DEV9: ATA: Failed to open HDD image '%s'", hddPath.c_str());
-		return -1;
+		hddChdImage = std::make_unique<ChdHddImage>();
+		if (!hddChdImage->Open(hddPath))
+		{
+			Console.Error("DEV9: ATA: Failed to open CHD HDD image '%s'", hddPath.c_str());
+			hddChdImage.reset();
+			return -1;
+		}
+		hddImageSize = hddChdImage->GetSize();
+	}
+	else
+	{
+		hddImage = FileSystem::OpenCFile(hddPath.c_str(), "r+b");
+		const s64 size = hddImage ? FileSystem::FSize64(hddImage) : -1;
+		if (!hddImage || size < 0)
+		{
+			Console.Error("DEV9: ATA: Failed to open HDD image '%s'", hddPath.c_str());
+			return -1;
+		}
+
+		hddImageSize = static_cast<u64>(size);
 	}
 
 	// Open and read the content of the hddid file
@@ -94,13 +111,12 @@ int ATA::Open(const std::string& hddPath)
 		// 0x80 and up - zero filled
 	}
 
-	//Store HddImage size for later use
-	hddImageSize = static_cast<u64>(size);
 	lba48Supported = (hddImageSize > ((static_cast<s64>(1) << 28) - 1) * 512);
 
 	CreateHDDinfo(hddImageSize / 512);
 
-	InitSparseSupport(hddPath);
+	if (!use_chd)
+		InitSparseSupport(hddPath);
 
 	{
 		std::lock_guard ioSignallock(ioMutex);
@@ -287,6 +303,7 @@ void ATA::Close()
 		std::fclose(hddImage);
 		hddImage = nullptr;
 	}
+	hddChdImage.reset();
 
 	delete[] readBuffer;
 	readBuffer = nullptr;
@@ -514,7 +531,7 @@ void ATA::Write(u32 addr, u16 value, int width)
 
 void ATA::Async(uint cycles)
 {
-	if (!hddImage)
+	if (!hddImage && !hddChdImage)
 		return;
 
 	if ((regStatus & (ATA_STAT_BUSY | ATA_STAT_DRQ)) == 0 ||

--- a/pcsx2/DEV9/ATA/ATA_Transfer.cpp
+++ b/pcsx2/DEV9/ATA/ATA_Transfer.cpp
@@ -5,6 +5,7 @@
 #include "common/FileSystem.h"
 
 #include "ATA.h"
+#include "HddChdImage.h"
 #include "DEV9/DEV9.h"
 
 #if __POSIX__
@@ -68,8 +69,17 @@ void ATA::IO_Read()
 	}
 
 	const u64 pos = lba * 512;
-	if (FileSystem::FSeek64(hddImage, pos, SEEK_SET) != 0 ||
-		std::fread(readBuffer,  512, nsector, hddImage) != static_cast<size_t>(nsector))
+	if (hddChdImage)
+	{
+		if (!hddChdImage->ReadSectors(lba, nsector, readBuffer))
+		{
+			Console.Error("DEV9: ATA: CHD file read error");
+			pxAssert(false);
+			abort();
+		}
+	}
+	else if (FileSystem::FSeek64(hddImage, pos, SEEK_SET) != 0 ||
+		std::fread(readBuffer, 512, nsector, hddImage) != static_cast<size_t>(nsector))
 	{
 		Console.Error("DEV9: ATA: File read error");
 		pxAssert(false);
@@ -92,6 +102,19 @@ bool ATA::IO_Write()
 	}
 
 	const u64 imagePos = entry.sector * 512;
+	if (hddChdImage)
+	{
+		if (!hddChdImage->WriteSectors(entry.sector, entry.length / 512, entry.data))
+		{
+			Console.Error("DEV9: ATA: CHD overlay write error");
+			pxAssert(false);
+			abort();
+		}
+
+		delete[] entry.data;
+		return true;
+	}
+
 	if (FileSystem::FSeek64(hddImage, imagePos, SEEK_SET) != 0)
 	{
 		Console.Error("DEV9: ATA: File seek error");

--- a/pcsx2/DEV9/ATA/HddChdImage.cpp
+++ b/pcsx2/DEV9/ATA/HddChdImage.cpp
@@ -150,6 +150,8 @@ bool ChdHddImage::OpenChd(const std::string& path)
 	m_logical_size = header->logicalbytes;
 	m_hunk_size = header->hunkbytes;
 	m_hunk_count = header->totalhunks;
+	DevCon.WriteLn("DEV9: ATA: CHD HDD logical size: %llu bytes, hunk size: %u bytes, hunks: %u",
+		static_cast<unsigned long long>(m_logical_size), m_hunk_size, m_hunk_count);
 
 	char metadata[256] = {};
 	if (chd_get_metadata(m_chd, HARD_DISK_METADATA_TAG, 0, metadata, sizeof(metadata), nullptr, nullptr, nullptr) == CHDERR_NONE)

--- a/pcsx2/DEV9/ATA/HddChdImage.cpp
+++ b/pcsx2/DEV9/ATA/HddChdImage.cpp
@@ -1,0 +1,535 @@
+// SPDX-FileCopyrightText: 2002-2026 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#include "HddChdImage.h"
+
+#include "common/Console.h"
+#include "common/MD5Digest.h"
+#include "common/Path.h"
+#include "common/StringUtil.h"
+
+#include "Config.h"
+
+#include "libchdr/chd.h"
+
+#include "fmt/format.h"
+
+#include <algorithm>
+#include <cstring>
+
+#if defined(_WIN32)
+#include "common/RedtapeWindows.h"
+#include <io.h>
+#include <winioctl.h>
+#elif defined(__POSIX__)
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#endif
+
+static constexpr char OVERLAY_MAP_MAGIC[8] = {'P', 'C', 'S', 'X', '2', 'H', 'O', 'V'};
+static constexpr u32 OVERLAY_MAP_VERSION = 1;
+
+ChdHddImage::ChdHddImage() = default;
+
+ChdHddImage::~ChdHddImage()
+{
+	Close();
+}
+
+bool ChdHddImage::Open(const std::string& path)
+{
+	Close();
+
+	if (!OpenChd(path))
+	{
+		Close();
+		return false;
+	}
+
+	if (!OpenOverlay(path))
+	{
+		Close();
+		return false;
+	}
+
+	return true;
+}
+
+void ChdHddImage::Close()
+{
+	m_overlay_map_file.reset();
+	m_overlay_file.reset();
+	m_overlay_map.clear();
+	m_overlay_block_buffer.clear();
+	m_overlay_block_count = 0;
+	m_overlay_path.clear();
+	m_overlay_map_path.clear();
+
+	for (HunkCacheEntry& entry : m_hunk_cache)
+	{
+		entry.hunk = UINT32_MAX;
+		entry.last_used = 0;
+		entry.data.clear();
+	}
+	m_hunk_cache_counter = 0;
+
+	if (m_chd)
+	{
+		chd_close(m_chd);
+		m_chd = nullptr;
+	}
+
+	m_chd_file_handle.reset();
+	m_logical_size = 0;
+	m_hunk_size = 0;
+	m_hunk_count = 0;
+}
+
+std::optional<u64> ChdHddImage::GetChdLogicalSize(const std::string& path)
+{
+	FileSystem::ManagedCFilePtr fp = FileSystem::OpenManagedSharedCFile(path.c_str(), "rb", FileSystem::FileShareMode::DenyWrite);
+	if (!fp)
+		return std::nullopt;
+
+	chd_header header;
+	const chd_error err = chd_read_header_file(fp.get(), &header);
+	if (err != CHDERR_NONE || header.logicalbytes == 0 || (header.logicalbytes % SECTOR_SIZE) != 0)
+		return std::nullopt;
+
+	return header.logicalbytes;
+}
+
+bool ChdHddImage::IsChdFileName(const std::string& path)
+{
+	return StringUtil::EndsWithNoCase(Path::GetExtension(path), "chd");
+}
+
+std::optional<u64> ChdHddImage::GetHddImageLogicalSize(const std::string& path)
+{
+	if (IsChdFileName(path))
+		return GetChdLogicalSize(path);
+
+	const s64 size = FileSystem::GetPathFileSize(path.c_str());
+	if (size < 0)
+		return std::nullopt;
+
+	return static_cast<u64>(size);
+}
+
+bool ChdHddImage::OpenChd(const std::string& path)
+{
+	m_chd_file_handle = FileSystem::OpenManagedSharedCFile(path.c_str(), "rb", FileSystem::FileShareMode::DenyWrite);
+	if (!m_chd_file_handle)
+	{
+		Console.Error("DEV9: ATA: Failed to open CHD HDD image '%s'", path.c_str());
+		return false;
+	}
+
+	chd_error err = chd_open_file(m_chd_file_handle.get(), CHD_OPEN_READ, nullptr, &m_chd);
+	if (err != CHDERR_NONE)
+	{
+		Console.Error("DEV9: ATA: Failed to open CHD HDD image '%s': %s", path.c_str(), chd_error_string(err));
+		return false;
+	}
+
+	const chd_header* header = chd_get_header(m_chd);
+	if (!header || header->logicalbytes == 0 || (header->logicalbytes % SECTOR_SIZE) != 0)
+	{
+		Console.Error("DEV9: ATA: CHD HDD image '%s' has an invalid logical size", path.c_str());
+		return false;
+	}
+
+	if (header->hunkbytes == 0 || header->totalhunks == 0)
+	{
+		Console.Error("DEV9: ATA: CHD HDD image '%s' has an invalid hunk layout", path.c_str());
+		return false;
+	}
+
+	m_logical_size = header->logicalbytes;
+	m_hunk_size = header->hunkbytes;
+	m_hunk_count = header->totalhunks;
+
+	char metadata[256] = {};
+	if (chd_get_metadata(m_chd, HARD_DISK_METADATA_TAG, 0, metadata, sizeof(metadata), nullptr, nullptr, nullptr) == CHDERR_NONE)
+	{
+		int cylinders = 0;
+		int heads = 0;
+		int sectors = 0;
+		int bytes_per_sector = 0;
+		if (std::sscanf(metadata, HARD_DISK_METADATA_FORMAT, &cylinders, &heads, &sectors, &bytes_per_sector) == 4 && bytes_per_sector != SECTOR_SIZE)
+		{
+			Console.Error("DEV9: ATA: CHD HDD image '%s' uses %d-byte sectors, only 512-byte sectors are supported", path.c_str(), bytes_per_sector);
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool ChdHddImage::OpenOverlay(const std::string& path)
+{
+	m_overlay_path = GetDefaultOverlayBasePath(path);
+	m_overlay_map_path = fmt::format("{}.map", m_overlay_path);
+	m_overlay_block_count = (m_logical_size + OVERLAY_BLOCK_SIZE - 1) / OVERLAY_BLOCK_SIZE;
+
+	const std::string overlay_directory(Path::GetDirectory(m_overlay_path));
+	if (!FileSystem::EnsureDirectoryExists(overlay_directory.c_str(), true))
+	{
+		Console.Error("DEV9: ATA: Failed to create CHD HDD overlay directory '%s'", overlay_directory.c_str());
+		return false;
+	}
+
+	const bool overlay_exists = FileSystem::FileExists(m_overlay_path.c_str());
+	const bool map_exists = FileSystem::FileExists(m_overlay_map_path.c_str());
+	if (overlay_exists != map_exists)
+	{
+		Console.Error("DEV9: ATA: CHD HDD overlay for '%s' is incomplete", path.c_str());
+		return false;
+	}
+
+	if (!overlay_exists && !CreateOverlayFiles())
+		return false;
+
+	m_overlay_file = FileSystem::OpenManagedCFile(m_overlay_path.c_str(), "r+b");
+	m_overlay_map_file = FileSystem::OpenManagedCFile(m_overlay_map_path.c_str(), "r+b");
+	if (!m_overlay_file || !m_overlay_map_file)
+	{
+		Console.Error("DEV9: ATA: Failed to open CHD HDD overlay '%s'", m_overlay_path.c_str());
+		return false;
+	}
+
+	return LoadOverlayMap();
+}
+
+bool ChdHddImage::CreateOverlayFiles()
+{
+	{
+		FileSystem::ManagedCFilePtr overlay = FileSystem::OpenManagedCFile(m_overlay_path.c_str(), "w+b");
+		if (!overlay)
+		{
+			Console.Error("DEV9: ATA: Failed to create CHD HDD overlay '%s'", m_overlay_path.c_str());
+			return false;
+		}
+	}
+
+	OverlayMapHeader header = {};
+	std::memcpy(header.magic, OVERLAY_MAP_MAGIC, sizeof(header.magic));
+	header.version = OVERLAY_MAP_VERSION;
+	header.block_size = OVERLAY_BLOCK_SIZE;
+	header.logical_size = m_logical_size;
+	header.block_count = m_overlay_block_count;
+
+	const size_t map_size = static_cast<size_t>((m_overlay_block_count + 7) / 8);
+	std::vector<u8> map(map_size, 0);
+
+	FileSystem::ManagedCFilePtr map_file = FileSystem::OpenManagedCFile(m_overlay_map_path.c_str(), "w+b");
+	if (!map_file || std::fwrite(&header, sizeof(header), 1, map_file.get()) != 1 ||
+		(map_size > 0 && std::fwrite(map.data(), map_size, 1, map_file.get()) != 1) ||
+		std::fflush(map_file.get()) != 0)
+	{
+		Console.Error("DEV9: ATA: Failed to create CHD HDD overlay map '%s'", m_overlay_map_path.c_str());
+		FileSystem::DeleteFilePath(m_overlay_path.c_str());
+		FileSystem::DeleteFilePath(m_overlay_map_path.c_str());
+		return false;
+	}
+
+	return true;
+}
+
+bool ChdHddImage::LoadOverlayMap()
+{
+	OverlayMapHeader header;
+	if (FileSystem::FSeek64(m_overlay_map_file.get(), 0, SEEK_SET) != 0 ||
+		std::fread(&header, sizeof(header), 1, m_overlay_map_file.get()) != 1)
+	{
+		Console.Error("DEV9: ATA: Failed to read CHD HDD overlay map '%s'", m_overlay_map_path.c_str());
+		return false;
+	}
+
+	if (std::memcmp(header.magic, OVERLAY_MAP_MAGIC, sizeof(header.magic)) != 0 ||
+		header.version != OVERLAY_MAP_VERSION ||
+		header.block_size != OVERLAY_BLOCK_SIZE ||
+		header.logical_size != m_logical_size ||
+		header.block_count != m_overlay_block_count)
+	{
+		Console.Error("DEV9: ATA: CHD HDD overlay map '%s' does not match the selected CHD", m_overlay_map_path.c_str());
+		return false;
+	}
+
+	const size_t map_size = static_cast<size_t>((m_overlay_block_count + 7) / 8);
+	m_overlay_map.resize(map_size);
+	if (map_size > 0 && std::fread(m_overlay_map.data(), map_size, 1, m_overlay_map_file.get()) != 1)
+	{
+		Console.Error("DEV9: ATA: Failed to read CHD HDD overlay map '%s'", m_overlay_map_path.c_str());
+		return false;
+	}
+
+	m_overlay_block_buffer.resize(OVERLAY_BLOCK_SIZE);
+	return InitializeOverlayFile();
+}
+
+bool ChdHddImage::InitializeOverlayFile()
+{
+	const u64 expected_size = m_overlay_block_count * static_cast<u64>(OVERLAY_BLOCK_SIZE);
+	const s64 current_size = FileSystem::FSize64(m_overlay_file.get());
+	if (current_size < 0)
+	{
+		Console.Error("DEV9: ATA: Failed to determine CHD HDD overlay size");
+		return false;
+	}
+
+	if (static_cast<u64>(current_size) == expected_size)
+		return true;
+
+#if defined(_WIN32)
+	HANDLE native_file = reinterpret_cast<HANDLE>(_get_osfhandle(_fileno(m_overlay_file.get())));
+	if (native_file == INVALID_HANDLE_VALUE)
+		return false;
+
+	FILE_SET_SPARSE_BUFFER sparse_setting;
+	sparse_setting.SetSparse = true;
+	DWORD temp;
+	DeviceIoControl(native_file, FSCTL_SET_SPARSE, &sparse_setting, sizeof(sparse_setting), nullptr, 0, &temp, nullptr);
+
+	LARGE_INTEGER seek_end;
+	seek_end.QuadPart = expected_size;
+	LARGE_INTEGER seek_start;
+	seek_start.QuadPart = 0;
+	if (SetFilePointerEx(native_file, seek_end, nullptr, FILE_BEGIN) == FALSE ||
+		SetEndOfFile(native_file) == FALSE ||
+		SetFilePointerEx(native_file, seek_start, nullptr, FILE_BEGIN) == FALSE)
+	{
+		return false;
+	}
+#elif defined(__POSIX__)
+	const int native_file = fileno(m_overlay_file.get());
+	if (native_file == -1 || ftruncate(native_file, expected_size) == -1 || lseek(native_file, 0, SEEK_SET) == -1)
+		return false;
+#else
+	if (FileSystem::FSeek64(m_overlay_file.get(), expected_size - 1, SEEK_SET) != 0 || std::fputc(0, m_overlay_file.get()) == EOF ||
+		FileSystem::FSeek64(m_overlay_file.get(), 0, SEEK_SET) != 0)
+	{
+		return false;
+	}
+#endif
+
+	return true;
+}
+
+bool ChdHddImage::ReadSectors(u64 sector, u32 count, void* dst)
+{
+	return ReadBytes(sector * SECTOR_SIZE, count * SECTOR_SIZE, static_cast<u8*>(dst));
+}
+
+bool ChdHddImage::WriteSectors(u64 sector, u32 count, const void* src)
+{
+	return WriteOverlayBytes(sector * SECTOR_SIZE, count * SECTOR_SIZE, static_cast<const u8*>(src));
+}
+
+bool ChdHddImage::ReadBytes(u64 offset, u32 size, u8* dst)
+{
+	u32 done = 0;
+	while (done < size)
+	{
+		const u64 current_offset = offset + done;
+		const u64 block_index = current_offset / OVERLAY_BLOCK_SIZE;
+		const u32 block_offset = static_cast<u32>(current_offset % OVERLAY_BLOCK_SIZE);
+		const u32 block_remaining = GetOverlayBlockSize(block_index) - block_offset;
+		const u32 read_size = std::min(size - done, block_remaining);
+
+		if (IsOverlayBlockPresent(block_index))
+		{
+			if (!ReadOverlayBytes(current_offset, read_size, dst + done))
+				return false;
+		}
+		else if (!ReadBaseBytes(current_offset, read_size, dst + done))
+		{
+			return false;
+		}
+
+		done += read_size;
+	}
+
+	return true;
+}
+
+bool ChdHddImage::ReadBaseBytes(u64 offset, u32 size, u8* dst)
+{
+	u32 done = 0;
+	while (done < size)
+	{
+		const u64 current_offset = offset + done;
+		const u32 hunk = static_cast<u32>(current_offset / m_hunk_size);
+		const u32 hunk_offset = static_cast<u32>(current_offset % m_hunk_size);
+		const u32 read_size = std::min(size - done, m_hunk_size - hunk_offset);
+
+		const u8* hunk_data;
+		if (!GetCachedHunk(hunk, &hunk_data))
+			return false;
+
+		std::memcpy(dst + done, hunk_data + hunk_offset, read_size);
+		done += read_size;
+	}
+
+	return true;
+}
+
+bool ChdHddImage::ReadOverlayBytes(u64 offset, u32 size, u8* dst)
+{
+	if (FileSystem::FSeek64(m_overlay_file.get(), offset, SEEK_SET) != 0 ||
+		std::fread(dst, size, 1, m_overlay_file.get()) != 1)
+	{
+		Console.Error("DEV9: ATA: CHD HDD overlay read error");
+		return false;
+	}
+
+	return true;
+}
+
+bool ChdHddImage::WriteOverlayBytes(u64 offset, u32 size, const u8* src)
+{
+	u32 done = 0;
+	while (done < size)
+	{
+		const u64 current_offset = offset + done;
+		const u64 block_index = current_offset / OVERLAY_BLOCK_SIZE;
+		const u32 block_offset = static_cast<u32>(current_offset % OVERLAY_BLOCK_SIZE);
+		const u32 block_size = GetOverlayBlockSize(block_index);
+		const u32 write_size = std::min(size - done, block_size - block_offset);
+
+		if (!IsOverlayBlockPresent(block_index))
+		{
+			if (!ReadBaseBytes(block_index * OVERLAY_BLOCK_SIZE, block_size, m_overlay_block_buffer.data()) ||
+				!WriteOverlayBlock(block_index, m_overlay_block_buffer.data(), block_size) ||
+				!SetOverlayBlockPresent(block_index))
+			{
+				return false;
+			}
+		}
+
+		if (FileSystem::FSeek64(m_overlay_file.get(), current_offset, SEEK_SET) != 0 ||
+			std::fwrite(src + done, write_size, 1, m_overlay_file.get()) != 1 ||
+			std::fflush(m_overlay_file.get()) != 0)
+		{
+			Console.Error("DEV9: ATA: CHD HDD overlay write error");
+			return false;
+		}
+
+		done += write_size;
+	}
+
+	return true;
+}
+
+bool ChdHddImage::ReadOverlayBlock(u64 block_index, u8* dst, u32 block_size)
+{
+	return ReadOverlayBytes(block_index * OVERLAY_BLOCK_SIZE, block_size, dst);
+}
+
+bool ChdHddImage::WriteOverlayBlock(u64 block_index, const u8* src, u32 block_size)
+{
+	if (FileSystem::FSeek64(m_overlay_file.get(), block_index * OVERLAY_BLOCK_SIZE, SEEK_SET) != 0 ||
+		std::fwrite(src, block_size, 1, m_overlay_file.get()) != 1 ||
+		std::fflush(m_overlay_file.get()) != 0)
+	{
+		Console.Error("DEV9: ATA: CHD HDD overlay block write error");
+		return false;
+	}
+
+	return true;
+}
+
+bool ChdHddImage::GetCachedHunk(u32 hunk, const u8** data)
+{
+	for (HunkCacheEntry& entry : m_hunk_cache)
+	{
+		if (entry.hunk == hunk)
+		{
+			entry.last_used = ++m_hunk_cache_counter;
+			*data = entry.data.data();
+			return true;
+		}
+	}
+
+	HunkCacheEntry* target = &m_hunk_cache[0];
+	for (HunkCacheEntry& entry : m_hunk_cache)
+	{
+		if (entry.hunk == UINT32_MAX)
+		{
+			target = &entry;
+			break;
+		}
+
+		if (entry.last_used < target->last_used)
+			target = &entry;
+	}
+
+	if (target->data.size() != m_hunk_size)
+		target->data.resize(m_hunk_size);
+
+	const chd_error err = chd_read(m_chd, hunk, target->data.data());
+	if (err != CHDERR_NONE)
+	{
+		Console.Error("DEV9: ATA: CHD HDD hunk read error: %s", chd_error_string(err));
+		return false;
+	}
+
+	target->hunk = hunk;
+	target->last_used = ++m_hunk_cache_counter;
+	*data = target->data.data();
+	return true;
+}
+
+bool ChdHddImage::IsOverlayBlockPresent(u64 block_index) const
+{
+	return (m_overlay_map[static_cast<size_t>(block_index / 8)] & (1u << (block_index % 8))) != 0;
+}
+
+bool ChdHddImage::SetOverlayBlockPresent(u64 block_index)
+{
+	u8& byte = m_overlay_map[static_cast<size_t>(block_index / 8)];
+	const u8 mask = static_cast<u8>(1u << (block_index % 8));
+	if ((byte & mask) != 0)
+		return true;
+
+	byte |= mask;
+	const s64 map_offset = sizeof(OverlayMapHeader) + static_cast<s64>(block_index / 8);
+	if (FileSystem::FSeek64(m_overlay_map_file.get(), map_offset, SEEK_SET) != 0 ||
+		std::fwrite(&byte, 1, 1, m_overlay_map_file.get()) != 1 ||
+		std::fflush(m_overlay_map_file.get()) != 0)
+	{
+		Console.Error("DEV9: ATA: CHD HDD overlay map write error");
+		return false;
+	}
+
+	return true;
+}
+
+u32 ChdHddImage::GetOverlayBlockSize(u64 block_index) const
+{
+	const u64 block_start = block_index * OVERLAY_BLOCK_SIZE;
+	return static_cast<u32>(std::min<u64>(OVERLAY_BLOCK_SIZE, m_logical_size - block_start));
+}
+
+std::string ChdHddImage::GetDefaultOverlayBasePath(const std::string& path) const
+{
+	u8 digest[16];
+	MD5Digest md5;
+	md5.Update(path.data(), static_cast<u32>(path.size()));
+	md5.Final(digest);
+
+	std::string hash;
+	hash.reserve(sizeof(digest) * 2);
+	for (const u8 value : digest)
+		hash += fmt::format("{:02x}", value);
+
+	std::string title(Path::GetFileTitle(path));
+	Path::SanitizeFileName(&title);
+	if (title.empty())
+		title = "hdd";
+
+	const std::string overlay_dir = Path::Combine(EmuFolders::Settings, "hdd-overlays");
+	return Path::Combine(overlay_dir, fmt::format("{}-{}.overlay", title, hash));
+}

--- a/pcsx2/DEV9/ATA/HddChdImage.h
+++ b/pcsx2/DEV9/ATA/HddChdImage.h
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2002-2026 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#pragma once
+
+#include "common/FileSystem.h"
+#include "common/Pcsx2Defs.h"
+
+#include <array>
+#include <cstdio>
+#include <optional>
+#include <string>
+#include <vector>
+
+typedef struct _chd_file chd_file;
+
+class ChdHddImage
+{
+public:
+	ChdHddImage();
+	~ChdHddImage();
+
+	bool Open(const std::string& path);
+	void Close();
+
+	u64 GetSize() const { return m_logical_size; }
+	const std::string& GetOverlayPath() const { return m_overlay_path; }
+
+	bool ReadSectors(u64 sector, u32 count, void* dst);
+	bool WriteSectors(u64 sector, u32 count, const void* src);
+
+	static std::optional<u64> GetChdLogicalSize(const std::string& path);
+	static bool IsChdFileName(const std::string& path);
+	static std::optional<u64> GetHddImageLogicalSize(const std::string& path);
+
+private:
+	static constexpr u32 SECTOR_SIZE = 512;
+	static constexpr u32 OVERLAY_BLOCK_SIZE = 64 * 1024;
+	static constexpr u32 HUNK_CACHE_SIZE = 4;
+
+	struct HunkCacheEntry
+	{
+		u32 hunk = UINT32_MAX;
+		u64 last_used = 0;
+		std::vector<u8> data;
+	};
+
+	struct OverlayMapHeader
+	{
+		char magic[8];
+		u32 version;
+		u32 block_size;
+		u64 logical_size;
+		u64 block_count;
+	};
+
+	bool OpenChd(const std::string& path);
+	bool OpenOverlay(const std::string& path);
+	bool CreateOverlayFiles();
+	bool LoadOverlayMap();
+	bool InitializeOverlayFile();
+	bool ReadBytes(u64 offset, u32 size, u8* dst);
+	bool ReadBaseBytes(u64 offset, u32 size, u8* dst);
+	bool ReadOverlayBytes(u64 offset, u32 size, u8* dst);
+	bool WriteOverlayBytes(u64 offset, u32 size, const u8* src);
+	bool ReadOverlayBlock(u64 block_index, u8* dst, u32 block_size);
+	bool WriteOverlayBlock(u64 block_index, const u8* src, u32 block_size);
+	bool GetCachedHunk(u32 hunk, const u8** data);
+	bool IsOverlayBlockPresent(u64 block_index) const;
+	bool SetOverlayBlockPresent(u64 block_index);
+	u32 GetOverlayBlockSize(u64 block_index) const;
+	std::string GetDefaultOverlayBasePath(const std::string& path) const;
+
+	FileSystem::ManagedCFilePtr m_chd_file_handle;
+	chd_file* m_chd = nullptr;
+	u64 m_logical_size = 0;
+	u32 m_hunk_size = 0;
+	u32 m_hunk_count = 0;
+
+	std::array<HunkCacheEntry, HUNK_CACHE_SIZE> m_hunk_cache;
+	u64 m_hunk_cache_counter = 0;
+
+	std::string m_overlay_path;
+	std::string m_overlay_map_path;
+	FileSystem::ManagedCFilePtr m_overlay_file;
+	FileSystem::ManagedCFilePtr m_overlay_map_file;
+	u64 m_overlay_block_count = 0;
+	std::vector<u8> m_overlay_map;
+	std::vector<u8> m_overlay_block_buffer;
+};

--- a/pcsx2/ImGui/FullscreenUI_Settings.cpp
+++ b/pcsx2/ImGui/FullscreenUI_Settings.cpp
@@ -18,6 +18,7 @@
 #include "USB/USB.h"
 #include "VMManager.h"
 #include "ps2/BiosTools.h"
+#include "DEV9/ATA/HddChdImage.h"
 #include "DEV9/ATA/HddCreate.h"
 #include "DEV9/pcap_io.h"
 #include "DEV9/sockets.h"
@@ -3974,17 +3975,20 @@ void FullscreenUI::DrawNetworkHDDSettingsPage()
 
 		FileSystem::FindResultsArray results;
 		FileSystem::FindFiles(EmuFolders::DataRoot.c_str(), "*.raw", FILESYSTEM_FIND_FILES | FILESYSTEM_FIND_HIDDEN_FILES, &results);
+		FileSystem::FindFiles(EmuFolders::DataRoot.c_str(), "*.chd", FILESYSTEM_FIND_FILES | FILESYSTEM_FIND_HIDDEN_FILES | FILESYSTEM_FIND_KEEP_ARRAY, &results);
+		FileSystem::FindFiles(EmuFolders::DataRoot.c_str(), "*.CHD", FILESYSTEM_FIND_FILES | FILESYSTEM_FIND_HIDDEN_FILES | FILESYSTEM_FIND_KEEP_ARRAY, &results);
 		for (const FILESYSTEM_FIND_DATA& fd : results)
 		{
 			const std::string full_path = fd.FileName;
 			const std::string filename = std::string(Path::GetFileName(full_path));
 
 			// Get file size and determine LBA mode
-			const s64 file_size = FileSystem::GetPathFileSize(full_path.c_str());
-			if (file_size > 0)
+			const std::optional<u64> logical_size = ChdHddImage::GetHddImageLogicalSize(full_path);
+			if (logical_size.has_value() && logical_size.value() > 0)
 			{
+				const u64 file_size = logical_size.value();
 				const int size_gb = static_cast<int>(file_size / _1gb);
-				const bool uses_lba48 = (file_size > static_cast<s64>(120) * _1gb);
+				const bool uses_lba48 = (file_size > static_cast<u64>(120) * _1gb);
 				const std::string lba_mode = uses_lba48 ? "LBA48" : "LBA28";
 
 				choices.emplace_back(fmt::format("{} ({} GB, {})", filename, size_gb, lba_mode),
@@ -4016,7 +4020,7 @@ void FullscreenUI::DrawNetworkHDDSettingsPage()
 							SettingsInterface* bsi = GetEditingSettingsInterface(game_settings);
 							bsi->SetStringValue("DEV9/Hdd", "HddFile", path.c_str());
 							SetSettingsChanged(bsi);
-							ShowToast(std::string(), fmt::format(FSUI_FSTR("Selected HDD image: {}"), Path::GetFileName(path))); }, {"*.raw", "*"}, EmuFolders::DataRoot);
+							ShowToast(std::string(), fmt::format(FSUI_FSTR("Selected HDD image: {}"), Path::GetFileName(path))); }, {"*.raw", "*.chd", "*"}, EmuFolders::DataRoot);
 				}
 				else if (values[index] == "__create__")
 				{

--- a/pcsx2/pcsx2.vcxproj
+++ b/pcsx2/pcsx2.vcxproj
@@ -178,6 +178,7 @@
     <ClCompile Include="DEV9\ATA\ATA_Info.cpp" />
     <ClCompile Include="DEV9\ATA\ATA_State.cpp" />
     <ClCompile Include="DEV9\ATA\ATA_Transfer.cpp" />
+    <ClCompile Include="DEV9\ATA\HddChdImage.cpp" />
     <ClCompile Include="DEV9\ATA\HddCreate.cpp" />
     <ClCompile Include="DEV9\DEV9.cpp" />
     <ClCompile Include="DEV9\flash.cpp" />
@@ -669,6 +670,7 @@
     <ClInclude Include="DebugTools\SymbolImporter.h" />
     <ClInclude Include="DEV9\AdapterUtils.h" />
     <ClInclude Include="DEV9\ATA\ATA.h" />
+    <ClInclude Include="DEV9\ATA\HddChdImage.h" />
     <ClInclude Include="DEV9\ATA\HddCreate.h" />
     <ClInclude Include="DEV9\DEV9.h" />
     <ClInclude Include="DEV9\InternalServers\DHCP_Logger.h" />

--- a/pcsx2/pcsx2.vcxproj.filters
+++ b/pcsx2/pcsx2.vcxproj.filters
@@ -863,6 +863,9 @@
     <ClCompile Include="DEV9\ATA\ATA_Transfer.cpp">
       <Filter>System\Ps2\DEV9\ATA</Filter>
     </ClCompile>
+    <ClCompile Include="DEV9\ATA\HddChdImage.cpp">
+      <Filter>System\Ps2\DEV9\ATA</Filter>
+    </ClCompile>
     <ClCompile Include="DEV9\ATA\HddCreate.cpp">
       <Filter>System\Ps2\DEV9\ATA</Filter>
     </ClCompile>
@@ -1758,6 +1761,9 @@
       <Filter>System\Ps2\DEV9</Filter>
     </ClInclude>
     <ClInclude Include="DEV9\ATA\ATA.h">
+      <Filter>System\Ps2\DEV9\ATA</Filter>
+    </ClInclude>
+    <ClInclude Include="DEV9\ATA\HddChdImage.h">
       <Filter>System\Ps2\DEV9\ATA</Filter>
     </ClInclude>
     <ClInclude Include="DEV9\ATA\HddCreate.h">


### PR DESCRIPTION
### Description of Changes
Adds support for using CHD-compressed internal HDD images for Python 2 titles. .chd HDD images are opened read-only as the base image, with writes redirected to persistent overlay files stored under hdd-overlays/ in the emulator settings directory.
Also updates HDD image selection/size handling to recognize .chd files and uses the CHD logical size instead of the compressed file size.
### Rationale behind Changes
Python 2 HDD images are large when stored as raw .raw files. Supporting CHD significantly reduces disk usage while keeping the source image immutable for MAME DAT comparison.