### PR TITLE
Feature/fix parallel gs overlays

### DIFF
--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -114,6 +114,7 @@ static RenderAPI GetAPIForRenderer(GSRendererType renderer)
 #endif
 
 		case GSRendererType::SW:
+		case GSRendererType::Null:
 			// Hack.
 			return RenderAPI::Vulkan;
 

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -73,6 +73,16 @@ GSRendererType GSGetCurrentRenderer()
 	return GSCurrentRenderer;
 }
 
+std::string GSGetDeviceName()
+{
+#ifdef HAVE_PARALLEL_GS
+	if (g_pgs_device)
+		return g_pgs_device->get_device().get_gpu_properties().deviceName;
+#endif
+
+	return g_gs_device ? g_gs_device->GetName() : std::string();
+}
+
 bool GSIsHardwareRenderer()
 {
 	// Null gets flagged as hw.
@@ -960,6 +970,23 @@ void GSgetInternalResolution(int* width, int* height)
 
 void GSgetStats(SmallStringBase& info)
 {
+#ifdef HAVE_PARALLEL_GS
+	if (g_pgs_renderer)
+	{
+		const ParallelGS::FlushStats& stats = g_pgs_renderer->GetLastFrameStats();
+		info.format("paraLLEl-GS | {} PRIM | {} RP | {} CPY | {} BAR | {} CLUT",
+			stats.num_primitives, stats.num_render_passes, stats.num_copies,
+			stats.num_copy_barriers, stats.num_palette_updates);
+		return;
+	}
+#endif
+
+	if (!g_gs_device)
+	{
+		info.assign("");
+		return;
+	}
+
 	GSPerfMon& pm = g_perfmon;
 	const char* api_name = GSDevice::RenderAPIToString(g_gs_device->GetRenderAPI());
 	if (GSCurrentRenderer == GSRendererType::SW)
@@ -1035,7 +1062,7 @@ void GSgetStats(SmallStringBase& info)
 
 void GSgetMemoryStats(SmallStringBase& info)
 {
-	if (!g_texture_cache)
+	if (!g_gs_device || !g_texture_cache)
 	{
 		info.assign("");
 		return;

--- a/pcsx2/GS/GS.h
+++ b/pcsx2/GS/GS.h
@@ -89,6 +89,7 @@ void GSUpdateDisplayWindow();
 void GSSetVSyncMode(GSVSyncMode mode, bool allow_present_throttle);
 
 GSRendererType GSGetCurrentRenderer();
+std::string GSGetDeviceName();
 bool GSIsHardwareRenderer();
 std::string GetDefaultAdapter();
 bool GSWantsExclusiveFullscreen();

--- a/pcsx2/GS/Renderers/Null/GSRendererNull.cpp
+++ b/pcsx2/GS/Renderers/Null/GSRendererNull.cpp
@@ -20,3 +20,8 @@ GSTexture* GSRendererNull::GetOutput(int i, float& scale, int& y_offset)
 {
 	return nullptr;
 }
+
+bool GSRendererNull::IsCoverageAlphaSupported()
+{
+	return false;
+}

--- a/pcsx2/GS/Renderers/Null/GSRendererNull.h
+++ b/pcsx2/GS/Renderers/Null/GSRendererNull.h
@@ -14,4 +14,5 @@ protected:
 	void VSync(u32 field, bool registers_written, bool idle_frame) override;
 	void Draw() override;
 	GSTexture* GetOutput(int i, float& scale, int& y_offset) override;
+	bool IsCoverageAlphaSupported() override;
 };

--- a/pcsx2/GS/Renderers/parallel-gs/GSRendererPGS.cpp
+++ b/pcsx2/GS/Renderers/parallel-gs/GSRendererPGS.cpp
@@ -651,10 +651,10 @@ void GSRendererPGS::VSync(u32 field, bool registers_written, bool refresh_frame)
 
 		// If we have CRT emulation, we deal with deinterlacing there.
 		info.skip_deinterlace = GSConfig.PGSPhosphorPrimaries != PGS_CRT_NONE;
-		auto stats = iface.consume_flush_stats();
+		last_frame_stats = iface.consume_flush_stats();
 
 		// Do not allow frame skip if frame-dupe is used.
-		frame_is_duped = !registers_written && stats.num_render_passes == 0 && stats.num_copies == 0 && iface.vsync_can_skip(info);
+		frame_is_duped = !registers_written && last_frame_stats.num_render_passes == 0 && last_frame_stats.num_copies == 0 && iface.vsync_can_skip(info);
 
 		// Don't waste GPU time scanning out the same thing twice.
 		if (!frame_is_duped || !vsync.image || !m_snapshot.empty())
@@ -663,7 +663,7 @@ void GSRendererPGS::VSync(u32 field, bool registers_written, bool refresh_frame)
 		if (frame_is_duped && !GSConfig.SkipDuplicateFrames)
 			wsi.set_next_present_is_duplicated();
 
-		PerformanceMetrics::Update(registers_written, stats.num_render_passes != 0, false);
+		PerformanceMetrics::Update(registers_written, last_frame_stats.num_render_passes != 0, false);
 	}
 
 	Host::BeginPresentFrame();

--- a/pcsx2/GS/Renderers/parallel-gs/GSRendererPGS.h
+++ b/pcsx2/GS/Renderers/parallel-gs/GSRendererPGS.h
@@ -112,6 +112,7 @@ public:
 	void UpdateConfig();
 
 	void GetInternalResolution(int *width, int *height);
+	const ParallelGS::FlushStats &GetLastFrameStats() const { return last_frame_stats; }
 
 	int Freeze(freezeData *data, bool sizeonly);
 	int Defrost(freezeData *data);
@@ -141,6 +142,7 @@ private:
 	ParallelGS::ScanoutResult vsync;
 
 	ParallelGS::SuperSampling current_super_sampling = ParallelGS::SuperSampling::X1;
+	ParallelGS::FlushStats last_frame_stats = {};
 	bool current_ordered_super_sampling = false;
 	bool current_super_sample_textures = false;
 	uint32_t last_internal_width = 0;

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -27,6 +27,7 @@
 #include "common/Console.h"
 #include "common/Error.h"
 #include "common/FileSystem.h"
+#include "common/Image.h"
 #include "common/Path.h"
 #include "common/SettingsInterface.h"
 #include "common/SmallString.h"
@@ -581,8 +582,6 @@ void FullscreenUI::Render()
 		LoadCustomBackground();
 	}
 
-	for (std::unique_ptr<GSTexture>& tex : s_cleanup_textures)
-		g_gs_device->Recycle(tex.release());
 	s_cleanup_textures.clear();
 	ImGuiFullscreen::UploadAsyncTextures();
 
@@ -767,8 +766,7 @@ void FullscreenUI::DestroyResources()
 	s_banner_texture.reset();
 	for (auto& tex : s_game_compatibility_textures)
 		tex.reset();
-	for (auto& tex : s_cleanup_textures)
-		g_gs_device->Recycle(tex.release());
+	s_cleanup_textures.clear();
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1902,15 +1900,10 @@ bool FullscreenUI::InitializeSaveStateListEntry(
 	std::vector<u32> screenshot_pixels;
 	if (SaveState_ReadScreenshot(li->path, &screenshot_width, &screenshot_height, &screenshot_pixels))
 	{
-		li->preview_texture =
-			std::unique_ptr<GSTexture>(g_gs_device->CreateTexture(screenshot_width, screenshot_height, 1, GSTexture::Format::Color));
-		if (!li->preview_texture || !li->preview_texture->Update(GSVector4i(0, 0, screenshot_width, screenshot_height),
-										screenshot_pixels.data(), sizeof(u32) * screenshot_width))
-		{
+		li->preview_texture = ImGuiFullscreen::UploadTexture(
+			li->path.c_str(), RGBA8Image(screenshot_width, screenshot_height, std::move(screenshot_pixels)));
+		if (!li->preview_texture)
 			Console.Error("Failed to upload save state image to GPU");
-			if (li->preview_texture)
-				g_gs_device->Recycle(li->preview_texture.release());
-		}
 	}
 
 	return true;

--- a/pcsx2/ImGui/FullscreenUI_Internal.h
+++ b/pcsx2/ImGui/FullscreenUI_Internal.h
@@ -274,7 +274,7 @@ namespace FullscreenUI
 	inline std::array<std::shared_ptr<GSTexture>, static_cast<u32>(GameDatabaseSchema::Compatibility::Perfect)>
 		s_game_compatibility_textures;
 	inline std::shared_ptr<GSTexture> s_banner_texture;
-	inline std::vector<std::unique_ptr<GSTexture>> s_cleanup_textures;
+	inline std::vector<std::shared_ptr<GSTexture>> s_cleanup_textures;
 
 	//////////////////////////////////////////////////////////////////////////
 	// Landing
@@ -315,7 +315,7 @@ namespace FullscreenUI
 		std::string title;
 		std::string summary;
 		std::string path;
-		std::unique_ptr<GSTexture> preview_texture;
+		std::shared_ptr<GSTexture> preview_texture;
 		time_t timestamp;
 		s32 slot;
 	};

--- a/pcsx2/ImGui/ImGuiFullscreen.cpp
+++ b/pcsx2/ImGui/ImGuiFullscreen.cpp
@@ -49,7 +49,6 @@ namespace ImGuiFullscreen
 	static constexpr float MENU_BACKGROUND_ANIMATION_TIME = 0.5f;
 
 	static std::optional<RGBA8Image> LoadTextureImage(const char* path);
-	static std::shared_ptr<GSTexture> UploadTexture(const char* path, const RGBA8Image& image);
 	static std::optional<RGBA8Image> LoadSvgTextureImage(const char* path, ImVec2 size, SvgScaling mode);
 	static void TextureLoaderThread();
 

--- a/pcsx2/ImGui/ImGuiFullscreen.h
+++ b/pcsx2/ImGui/ImGuiFullscreen.h
@@ -18,6 +18,7 @@
 #include <vector>
 
 class GSTexture;
+class RGBA8Image;
 enum class InputLayout : u8;
 
 namespace ImGuiFullscreen
@@ -108,6 +109,7 @@ namespace ImGuiFullscreen
 
 	/// Texture cache.
 	const std::shared_ptr<GSTexture>& GetPlaceholderTexture();
+	std::shared_ptr<GSTexture> UploadTexture(const char* path, const RGBA8Image& image);
 	std::shared_ptr<GSTexture> LoadTexture(std::string_view path);
 	GSTexture* GetCachedTexture(std::string_view name);
 	GSTexture* GetCachedTextureAsync(std::string_view name);

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -439,7 +439,7 @@ __ri void ImGuiManager::DrawPerformanceOverlay(float& position_y, float scale, f
 				DRAW_LINE(osd_font, font_size, s_hardware_info_cpu_line.c_str(), white_color);
 
 				// GPU
-				s_hardware_info_gpu_line.format("GPU: {}{}", g_gs_device->GetName(), GSConfig.UseDebugDevice ? " (Debug)" : "");
+				s_hardware_info_gpu_line.format("GPU: {}{}", GSGetDeviceName(), GSConfig.UseDebugDevice ? " (Debug)" : "");
 				DRAW_LINE(osd_font, font_size, s_hardware_info_gpu_line.c_str(), white_color);
 			}
 

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -34,6 +34,7 @@
 #include "common/BitUtils.h"
 #include "common/Error.h"
 #include "common/FileSystem.h"
+#include "common/Image.h"
 #include "common/Path.h"
 #include "common/Timer.h"
 
@@ -1349,7 +1350,7 @@ namespace SaveStateSelectorUI
 			std::string title;
 			std::string summary;
 			std::string filename;
-			std::unique_ptr<GSTexture> preview_texture;
+			std::shared_ptr<GSTexture> preview_texture;
 		};
 	} // namespace
 
@@ -1438,10 +1439,7 @@ void SaveStateSelectorUI::Close()
 void SaveStateSelectorUI::RefreshList(const std::string& serial, u32 crc)
 {
 	for (ListEntry& entry : s_slots)
-	{
-		if (entry.preview_texture)
-			g_gs_device->Recycle(entry.preview_texture.release());
-	}
+		entry.preview_texture.reset();
 
 	for (u32 i = 0; i < VMManager::NUM_SAVE_STATE_SLOTS; i++)
 		InitializeListEntry(serial, crc, &s_slots[i], static_cast<s32>(i + 1));
@@ -1455,9 +1453,7 @@ void SaveStateSelectorUI::Clear()
 	{
 		if (li.preview_texture)
 		{
-			MTGS::RunOnGSThread([tex = li.preview_texture.release()]() {
-				g_gs_device->Recycle(tex);
-			});
+			MTGS::RunOnGSThread([tex = std::move(li.preview_texture)]() mutable { tex.reset(); });
 		}
 
 		li = {};
@@ -1471,10 +1467,7 @@ void SaveStateSelectorUI::DestroyTextures()
 	Close();
 
 	for (ListEntry& entry : s_slots)
-	{
-		if (entry.preview_texture)
-			g_gs_device->Recycle(entry.preview_texture.release());
-	}
+		entry.preview_texture.reset();
 
 	s_placeholder_texture.reset();
 }
@@ -1558,15 +1551,10 @@ void SaveStateSelectorUI::InitializeListEntry(const std::string& serial, u32 crc
 	std::vector<u32> screenshot_pixels;
 	if (SaveState_ReadScreenshot(path, &screenshot_width, &screenshot_height, &screenshot_pixels))
 	{
-		li->preview_texture =
-			std::unique_ptr<GSTexture>(g_gs_device->CreateTexture(screenshot_width, screenshot_height, 1, GSTexture::Format::Color));
-		if (!li->preview_texture || !li->preview_texture->Update(GSVector4i(0, 0, screenshot_width, screenshot_height),
-										screenshot_pixels.data(), sizeof(u32) * screenshot_width))
-		{
+		li->preview_texture = ImGuiFullscreen::UploadTexture(
+			path.c_str(), RGBA8Image(screenshot_width, screenshot_height, std::move(screenshot_pixels)));
+		if (!li->preview_texture)
 			Console.Error("Failed to upload save state image to GPU");
-			if (li->preview_texture)
-				g_gs_device->Recycle(li->preview_texture.release());
-		}
 	}
 }
 


### PR DESCRIPTION
### Description of Changes
- Add paraLLEl-GS support to the performance and hardware information overlays.
- Retrieve the active GPU name correctly when rendering with PGS.
- Expose paraLLEl-GS statistics for the GS statistics overlay.
- FIx save-state preview images crashing on PGS
- Correct null-renderer API selection to aid with perf benchmarks of soft-float.