### PR TITLE
Flatpack SteamDeck/Gamescope HDR Support

### DIFF
--- a/.github/workflows/cron_publish_flatpak.yml
+++ b/.github/workflows/cron_publish_flatpak.yml
@@ -24,7 +24,7 @@ jobs:
 # for 24 hours.
 
 #  check:
-#    if: github.repository == 'PCSX2/pcsx2'
+#    if: github.repository == 'DiscoStarslayer/pcsx2-reliquary'
 #    name: "Check if release is needed"
 #    runs-on: ubuntu-latest
 #    timeout-minutes: 180
@@ -38,7 +38,7 @@ jobs:
 #          GH_TOKEN: ${{ github.token }}
 #        run: |
 #          PCSX2_RELEASE=$(gh api -H 'Accept: application/vnd.github+json' -H 'X-GitHub-Api-Version: 2022-11-28' /repos/PCSX2/pcsx2/releases | jq -r '.[0].tag_name')
-#          FLATHUB_RELEASE=$(curl -L -s https://flathub.org/api/v2/appstream/net.pcsx2.PCSX2 | jq -r '.releases | max_by(.version) | .version')
+#          FLATHUB_RELEASE=$(curl -L -s https://flathub.org/api/v2/appstream/io.github.DiscoStarslayer.pcsx2-reliquary | jq -r '.releases | max_by(.version) | .version')
 #          echo "Latest PCSX2 release is: '${PCSX2_RELEASE}'"
 #          echo "Latest Flathub release is: '${FLATHUB_RELEASE}'"
 #          PCSX2_RELEASE=$(echo $PCSX2_RELEASE | sed 's/[^0-9]*//g')
@@ -55,16 +55,15 @@ jobs:
 
 #   if: fromJson(needs.check.outputs.FLATHUB_RELEASE) < fromJson(needs.check.outputs.PCSX2_RELEASE)
     # As the check step is disabled, perform repository check here
-    if: github.repository == 'PCSX2/pcsx2'
+    if: github.repository == 'DiscoStarslayer/pcsx2-reliquary'
     name: "Build and publish Flatpak"
     uses: ./.github/workflows/linux_build_flatpak.yml
     with:
       jobName: "Qt"
-      artifactPrefixName: "PCSX2-linux-Qt-x64-flatpak"
+      artifactPrefixName: "PCSX2-Reliquary-linux-Qt-x64-flatpak"
       compiler: clang
       cmakeflags: ""
       publish: ${{ inputs.publish || true }}
       fetchTags: true
       stableBuild: ${{ inputs.stableBuild || false }}
     secrets: inherit
-

--- a/.github/workflows/linux_build_flatpak.yml
+++ b/.github/workflows/linux_build_flatpak.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Validate manifest
         run: |
-          flatpak-builder-lint manifest .github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
+          flatpak-builder-lint manifest .github/workflows/scripts/linux/flatpak/io.github.DiscoStarslayer.pcsx2-reliquary.json
 
       - name: Build Flatpak (beta)
         if: ${{ inputs.stableBuild == false || inputs.stableBuild == 'false' }}
@@ -98,7 +98,7 @@ jobs:
         with:
           bundle: ${{ steps.artifact-metadata.outputs.artifact-name }}.flatpak
           upload-artifact: false
-          manifest-path: .github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
+          manifest-path: .github/workflows/scripts/linux/flatpak/io.github.DiscoStarslayer.pcsx2-reliquary.json
           arch: x86_64
           build-bundle: true
           verbose: true
@@ -114,7 +114,7 @@ jobs:
         with:
           bundle: ${{ steps.artifact-metadata.outputs.artifact-name }}.flatpak
           upload-artifact: false
-          manifest-path: .github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
+          manifest-path: .github/workflows/scripts/linux/flatpak/io.github.DiscoStarslayer.pcsx2-reliquary.json
           arch: x86_64
           build-bundle: true
           verbose: true

--- a/.github/workflows/scripts/linux/flatpak/io.github.DiscoStarslayer.pcsx2-reliquary.json
+++ b/.github/workflows/scripts/linux/flatpak/io.github.DiscoStarslayer.pcsx2-reliquary.json
@@ -1,5 +1,5 @@
 {
-  "app-id": "net.pcsx2.PCSX2",
+  "app-id": "io.github.DiscoStarslayer.pcsx2-reliquary",
   "runtime": "org.kde.Platform",
   "runtime-version": "6.10",
   "sdk": "org.kde.Sdk",
@@ -78,12 +78,13 @@
       ],
       "post-install": [
         "cp -a bin \"${FLATPAK_DEST}\"",
-        "install -Dm644 \"${FLATPAK_BUILDER_BUILDDIR}/bin/resources/icons/AppIconLarge.png\" \"${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/net.pcsx2.PCSX2.png\"",
-        "install -Dm644 \"${FLATPAK_BUILDER_BUILDDIR}/.github/workflows/scripts/linux/pcsx2-qt.desktop\" \"${FLATPAK_DEST}/share/applications/net.pcsx2.PCSX2.desktop\"",
-        "desktop-file-edit --set-key=Icon --set-value=net.pcsx2.PCSX2 \"${FLATPAK_DEST}/share/applications/net.pcsx2.PCSX2.desktop\"",
-        "${FLATPAK_BUILDER_BUILDDIR}/.github/workflows/scripts/linux/generate-metainfo.sh \"${FLATPAK_BUILDER_BUILDDIR}/net.pcsx2.PCSX2.metainfo.xml\"",
-        "cat \"${FLATPAK_BUILDER_BUILDDIR}/net.pcsx2.PCSX2.metainfo.xml\"",
-        "install -Dm644 \"${FLATPAK_BUILDER_BUILDDIR}/net.pcsx2.PCSX2.metainfo.xml\" \"${FLATPAK_DEST}/share/metainfo/net.pcsx2.PCSX2.metainfo.xml\"",
+        "install -Dm644 \"${FLATPAK_BUILDER_BUILDDIR}/bin/resources/icons/AppIconLarge.png\" \"${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/io.github.DiscoStarslayer.pcsx2-reliquary.png\"",
+        "install -Dm644 \"${FLATPAK_BUILDER_BUILDDIR}/.github/workflows/scripts/linux/pcsx2-qt.desktop\" \"${FLATPAK_DEST}/share/applications/io.github.DiscoStarslayer.pcsx2-reliquary.desktop\"",
+        "desktop-file-edit --set-key=Name --set-value=PCSX2-Reliquary \"${FLATPAK_DEST}/share/applications/io.github.DiscoStarslayer.pcsx2-reliquary.desktop\"",
+        "desktop-file-edit --set-key=Icon --set-value=io.github.DiscoStarslayer.pcsx2-reliquary \"${FLATPAK_DEST}/share/applications/io.github.DiscoStarslayer.pcsx2-reliquary.desktop\"",
+        "PCSX2_APP_ID=io.github.DiscoStarslayer.pcsx2-reliquary PCSX2_APP_NAME=PCSX2-Reliquary PCSX2_GITHUB_REPOSITORY=DiscoStarslayer/pcsx2-reliquary ${FLATPAK_BUILDER_BUILDDIR}/.github/workflows/scripts/linux/generate-metainfo.sh \"${FLATPAK_BUILDER_BUILDDIR}/io.github.DiscoStarslayer.pcsx2-reliquary.metainfo.xml\"",
+        "cat \"${FLATPAK_BUILDER_BUILDDIR}/io.github.DiscoStarslayer.pcsx2-reliquary.metainfo.xml\"",
+        "install -Dm644 \"${FLATPAK_BUILDER_BUILDDIR}/io.github.DiscoStarslayer.pcsx2-reliquary.metainfo.xml\" \"${FLATPAK_DEST}/share/metainfo/io.github.DiscoStarslayer.pcsx2-reliquary.metainfo.xml\"",
         "mkdir -p \"${FLATPAK_DEST}/lib/ffmpeg\"",
         "mkdir -p \"${FLATPAK_DEST}/lib/extensions/vulkan/gamescope\""
       ]

--- a/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
+++ b/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
@@ -12,6 +12,12 @@
       "version": "25.08",
       "add-ld-path": ".",
       "autodownload": true
+    },
+    "org.freedesktop.Platform.VulkanLayer.gamescope": {
+      "directory": "lib/extensions/vulkan/gamescope",
+      "version": "25.08",
+      "autodownload": true,
+      "autodelete": false
     }
   },
   "command": "pcsx2-qt",
@@ -23,7 +29,9 @@
     "--socket=fallback-x11",
     "--socket=pulseaudio",
     "--talk-name=org.freedesktop.ScreenSaver",
-    "--filesystem=xdg-run/gamescope-0:ro"
+    "--filesystem=xdg-run/gamescope-0:ro",
+    "--env=LD_LIBRARY_PATH=/usr/lib/extensions/vulkan/gamescope/lib",
+    "--env=XDG_DATA_DIRS=/app/share:/usr/lib/extensions/vulkan/share:/usr/share:/usr/share/runtime/share:/run/host/user-share:/run/host/share"
   ],
   "modules": [
     "modules/10-libpcap.json",
@@ -76,7 +84,8 @@
         "${FLATPAK_BUILDER_BUILDDIR}/.github/workflows/scripts/linux/generate-metainfo.sh \"${FLATPAK_BUILDER_BUILDDIR}/net.pcsx2.PCSX2.metainfo.xml\"",
         "cat \"${FLATPAK_BUILDER_BUILDDIR}/net.pcsx2.PCSX2.metainfo.xml\"",
         "install -Dm644 \"${FLATPAK_BUILDER_BUILDDIR}/net.pcsx2.PCSX2.metainfo.xml\" \"${FLATPAK_DEST}/share/metainfo/net.pcsx2.PCSX2.metainfo.xml\"",
-        "mkdir -p \"${FLATPAK_DEST}/lib/ffmpeg\""
+        "mkdir -p \"${FLATPAK_DEST}/lib/ffmpeg\"",
+        "mkdir -p \"${FLATPAK_DEST}/lib/extensions/vulkan/gamescope\""
       ]
     }
   ]

--- a/.github/workflows/scripts/linux/generate-metainfo.sh
+++ b/.github/workflows/scripts/linux/generate-metainfo.sh
@@ -8,6 +8,9 @@ if [[ $# -lt 1 ]]; then
 fi
 
 OUTFILE=$1
+APP_ID=${PCSX2_APP_ID:-net.pcsx2.PCSX2}
+APP_NAME=${PCSX2_APP_NAME:-PCSX2}
+GITHUB_REPOSITORY=${PCSX2_GITHUB_REPOSITORY:-PCSX2/pcsx2}
 GIT_DATE=$(git log -1 --pretty=%cd --date=iso8601)
 GIT_VERSION=$(git tag --points-at HEAD)
 GIT_HASH=$(git rev-parse HEAD)
@@ -38,7 +41,9 @@ echo "GIT_HASH: ${GIT_HASH}"
 
 cp "${SCRIPTDIR}"/pcsx2-qt.metainfo.xml.in "${OUTFILE}"
 
+sed -i -e "s|@APP_ID@|${APP_ID}|g" "${OUTFILE}"
+sed -i -e "s|@APP_NAME@|${APP_NAME}|g" "${OUTFILE}"
+sed -i -e "s|@GITHUB_REPOSITORY@|${GITHUB_REPOSITORY}|g" "${OUTFILE}"
 sed -i -e "s/@GIT_VERSION@/${GIT_VERSION}/" "${OUTFILE}"
 sed -i -e "s/@GIT_DATE@/${GIT_DATE}/" "${OUTFILE}"
 sed -i -e "s/@GIT_HASH@/${GIT_HASH}/" "${OUTFILE}"
-

--- a/.github/workflows/scripts/linux/pcsx2-qt.metainfo.xml.in
+++ b/.github/workflows/scripts/linux/pcsx2-qt.metainfo.xml.in
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Uses the AppStream standard https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html -->
 <component type="desktop">
-  <id>net.pcsx2.PCSX2</id>
-  <launchable type="desktop-id">net.pcsx2.PCSX2.desktop</launchable>
+  <id>@APP_ID@</id>
+  <launchable type="desktop-id">@APP_ID@.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0+</project_license>
-  <name>PCSX2</name>
+  <name>@APP_NAME@</name>
   <developer id="net.pcsx2">
     <name>PCSX2 Team</name>
   </developer>
@@ -15,8 +15,8 @@
     <p>PlayStation 2 and PS2 are registered trademarks of Sony Interactive Entertainment. This application is not affiliated in any way with Sony Interactive Entertainment.</p>
   </description>
   <url type="homepage">https://pcsx2.net/</url>
-  <url type="vcs-browser">https://github.com/PCSX2/pcsx2</url>
-  <url type="bugtracker">https://github.com/PCSX2/pcsx2/issues</url>
+  <url type="vcs-browser">https://github.com/@GITHUB_REPOSITORY@</url>
+  <url type="bugtracker">https://github.com/@GITHUB_REPOSITORY@/issues</url>
   <url type="donation">https://github.com/sponsors/PCSX2</url>
   <url type="faq">https://pcsx2.net/docs/</url>
   <url type="help">https://pcsx2.net/discord</url>
@@ -67,6 +67,6 @@
     <release version="@GIT_VERSION@" date="@GIT_DATE@" />
   </releases>
   <custom>
-    <value key="flathub::manifest">https://raw.githubusercontent.com/PCSX2/pcsx2/@GIT_HASH@/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json</value>
+    <value key="flathub::manifest">https://raw.githubusercontent.com/@GITHUB_REPOSITORY@/@GIT_HASH@/.github/workflows/scripts/linux/flatpak/@APP_ID@.json</value>
   </custom>
 </component>


### PR DESCRIPTION
### Description of Changes
Parallel-GS supports HDR output to compensate for the dimming of the screen caused by CRT emulation. These changes ensure the HDR functionality works correctly through gamescope, tested on my Steam Deck OLED.